### PR TITLE
Disallow prototype path override - checking magic attributes

### DIFF
--- a/src/set.ts
+++ b/src/set.ts
@@ -1,12 +1,16 @@
 import each from 'lodash/each'
 import get from 'lodash/get'
 import _set from 'lodash/set'
+import { disallowProtoPath } from './utils'
 
 type Many<T> = T | ReadonlyArray<T>
 
 export const set = <T extends object>(object: T, value: any, ...paths: Array<Many<string | number | symbol>>) => {
 
-  each(paths, path => _set(object, path, typeof value !== 'function' ? value : value(get(object, path), path, object)))
+  each(paths, path => {
+    disallowProtoPath(path)
+    return _set(object, path, typeof value !== 'function' ? value : value(get(object, path), path, object))
+  })
 
   return object
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,26 @@
+/**
+ * Utilities and helper functions
+ */
+
+import { toPath } from "lodash";
+
+type Many<T> = T | ReadonlyArray<T>
+
+const ILLEGAL_KEYS = new Set(["constructor", "__proto__"]);
+
+export const isIllegalKey = (key: Many<string | number | symbol>): boolean => typeof key === "string"
+  ? ILLEGAL_KEYS.has(key)
+  : false
+
+export const isProtoPath = (path: Array<Many<string | number | symbol>> | Many<string | number | symbol>): boolean => Array.isArray(path)
+  ? path.some(isIllegalKey)
+  : typeof path === "string"
+    ? isIllegalKey(path)
+    : false;
+
+export const disallowProtoPath = (paths: Array<Many<string | number | symbol>> | Many<string | number | symbol>): void => {
+  const path = toPath(paths)
+  if (isProtoPath(path)) {
+    throw new Error(`Unsafe path encountered: ${path.toString()}`)
+  }
+}

--- a/test/set.test.ts
+++ b/test/set.test.ts
@@ -11,3 +11,7 @@ test(`Value can bea function that invoked to preduce the actual value to set`, (
     anotherProp: 1,
     0: [1]
 }))
+
+test(`Disallow protopath override by throwing exception when unsafe path encountered`, () => expect(() => set({}, 'test', '__proto__.polluted')).toThrow())
+
+test(`Disallow protopath override by throwing exception when unsafe path encountered`, () => expect(() => set({}, 'test', 'constructor.prototype.polluted')).toThrow())


### PR DESCRIPTION
### 📊 Metadata *

`set-each` is vulnerable to Prototype Pollution. This package fails to restrict access to prototypes of objects, allowing for modification of prototype behavior using a `__proto__`payload, which may result in Sensitive Information Disclosure/Denial of Service(DoS)/Remote Code Execution.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-set-each/

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes. The bug is fixed by validating the input strArray to check for prototypes. It is implemented by a simple validation to check for prototype keywords (proto, constructor and prototype), where if it exists, the function throws exception, thus fixing the Prototype Pollution Vulnerability.

### 🐛 Proof of Concept (PoC) *


1. Create the following PoC file:

```
// poc.js
var setEach = require("set-each")
const obj = [{}]
console.log("Before : " + {}.polluted); 
setEach.setEach(obj, 'Yes! Its Polluted', '__proto__.polluted')
console.log("After : " + {}.polluted);
```

2. Execute the following commands in another terminal:

```
npm i set-each # Install affected module
node poc.js #  Run the PoC
```

3. Check the Output:

```
Before : undefined
After : Yes! It's Polluted
```

### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/106709106-055b8980-661a-11eb-9715-f1b7b9c33f92.png)

After:
![image](https://user-images.githubusercontent.com/64132745/106709192-258b4880-661a-11eb-8d22-671b5f38eb7b.png)


### 👍 User Acceptance Testing (UAT)

After the fix, functionality is unaffected.

![image](https://user-images.githubusercontent.com/64132745/106710417-e958e780-661b-11eb-8fd2-24b1c7d78308.png)


### 🔗 Relates to...

https://github.com/418sec/huntr/pull/1825
