### PR TITLE
Upgrade lodash to fix prototype pollution

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,13 +16,13 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "lodash": "4.17.15",
+    "lodash": "5.0.0",
     "number-to-words": "1.2.4",
     "string-similarity": "3.0.0"
   },
   "devDependencies": {
     "@types/jest": "24.0.18",
-    "@types/lodash": "4.14.138",
+    "@types/lodash": "4.17.20",
     "@types/node": "12.7.5",
     "@types/number-to-words": "1.2.0",
     "@types/parcel-bundler": "1.12.1",


### PR DESCRIPTION
Fix for prototype pollution, The cause for prototype pollution is using vulnerable version of lodash module.

### 📊 Metadata *

_Please enter the direct URL for this bounty on huntr.dev. This is compulsory and will help us process your bounty submission quicker._

#### Bounty URL: https://huntr.dev/bounties/1-npm-utilizes.set/

### ⚙️ Description *

As simple as upgrading lodash module to fix

